### PR TITLE
linux: harden startup against race conditions\n\n- Use atomic plugin …

### DIFF
--- a/bitsdojo_window_linux/lib/src/app_window.dart
+++ b/bitsdojo_window_linux/lib/src/app_window.dart
@@ -13,8 +13,13 @@ class BitsDojoNotInitializedException implements Exception {
 
 class GtkAppWindow extends GtkWindow {
   GtkAppWindow._() {
-    super.handle = native.getAppWindowHandle();
-    assert(handle != null, "Could not get Flutter window");
+    final h = native.getAppWindowHandle();
+    if (h != 0) {
+      super.handle = h;
+    } else {
+      // Defer initialization; handle will be set once ready.
+      super.handle = null;
+    }
   }
 
   static final GtkAppWindow _instance = GtkAppWindow._();

--- a/bitsdojo_window_linux/lib/src/app_window.dart
+++ b/bitsdojo_window_linux/lib/src/app_window.dart
@@ -23,6 +23,7 @@ class GtkAppWindow extends GtkWindow {
   }
 
   static final GtkAppWindow _instance = GtkAppWindow._();
+  static GtkAppWindow get instance => _instance;
 
   factory GtkAppWindow() {
     return _instance;

--- a/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
+++ b/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
@@ -1,5 +1,6 @@
 library bitsdojo_window_linux;
 
+import 'package:bitsdojo_window_linux/src/native_api.dart' as native;
 import 'package:bitsdojo_window_platform_interface/bitsdojo_window_platform_interface.dart';
 import './window.dart';
 import './app_window.dart';
@@ -19,9 +20,12 @@ class BitsdojoWindowLinux extends BitsdojoWindowPlatform {
       // frame is rasterized. If still not ready, caller ops will no-op safely.
       final app = GtkAppWindow();
       if (app.handle == null || app.handle == 0) {
-        final h = native.getAppWindowHandle();
-        if (h != 0) {
-          app.handle = h;
+        // Prefer readiness probe to avoid spurious early calls.
+        if (native.isAppWindowReady() != 0) {
+          final h = native.getAppWindowHandle();
+          if (h != 0) {
+            app.handle = h;
+          }
         }
       }
       isInsideDoWhenWindowReady = true;

--- a/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
+++ b/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
@@ -20,8 +20,8 @@ class BitsdojoWindowLinux extends BitsdojoWindowPlatform {
       // frame is rasterized. If still not ready, caller ops will no-op safely.
       // Prefer readiness probe to avoid touching the singleton early.
       if (native.isAppWindowReady() != 0) {
-        final app = GtkAppWindow();
-        if (app.handle == null || app.handle == 0) {
+        final app = GtkAppWindow.instance;
+        if (!isValidHandle(app.handle, "initialize handle")) {
           final h = native.getAppWindowHandle();
           if (h != 0) {
             app.handle = h;

--- a/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
+++ b/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
@@ -18,10 +18,10 @@ class BitsdojoWindowLinux extends BitsdojoWindowPlatform {
         .then((value) {
       // Attempt to ensure the native window handle is ready once the first
       // frame is rasterized. If still not ready, caller ops will no-op safely.
-      final app = GtkAppWindow();
-      if (app.handle == null || app.handle == 0) {
-        // Prefer readiness probe to avoid spurious early calls.
-        if (native.isAppWindowReady() != 0) {
+      // Prefer readiness probe to avoid touching the singleton early.
+      if (native.isAppWindowReady() != 0) {
+        final app = GtkAppWindow();
+        if (app.handle == null || app.handle == 0) {
           final h = native.getAppWindowHandle();
           if (h != 0) {
             app.handle = h;

--- a/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
+++ b/bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart
@@ -15,6 +15,15 @@ class BitsdojoWindowLinux extends BitsdojoWindowPlatform {
     _ambiguate(WidgetsBinding.instance)!
         .waitUntilFirstFrameRasterized
         .then((value) {
+      // Attempt to ensure the native window handle is ready once the first
+      // frame is rasterized. If still not ready, caller ops will no-op safely.
+      final app = GtkAppWindow();
+      if (app.handle == null || app.handle == 0) {
+        final h = native.getAppWindowHandle();
+        if (h != 0) {
+          app.handle = h;
+        }
+      }
       isInsideDoWhenWindowReady = true;
       callback();
       isInsideDoWhenWindowReady = false;

--- a/bitsdojo_window_linux/lib/src/native_api.dart
+++ b/bitsdojo_window_linux/lib/src/native_api.dart
@@ -93,6 +93,12 @@ typedef Void TSetWindowTitle(IntPtr window, Pointer<Utf8> title);
 typedef DSetWindowTitle = void Function(int window, Pointer<Utf8> title);
 final DSetWindowTitle setWindowTitle = _theAPI.ref.setWindowTitle.asFunction();
 
+// isAppWindowReady
+typedef Int32 TIsAppWindowReady();
+typedef DIsAppWindowReady = int Function();
+final DIsAppWindowReady isAppWindowReady =
+    _theAPI.ref.isAppWindowReady.asFunction();
+
 class BDWAPI extends Struct {
   external Pointer<NativeFunction<TGetAppWindowHandle>> getAppWindowHandle;
   external Pointer<NativeFunction<TGetScreenRect>> getScreenRect;
@@ -110,6 +116,7 @@ class BDWAPI extends Struct {
   external Pointer<NativeFunction<TMaximizeWindow>> maximizeWindow;
   external Pointer<NativeFunction<TUnmaximizeWindow>> unmaximizeWindow;
   external Pointer<NativeFunction<TSetWindowTitle>> setWindowTitle;
+  external Pointer<NativeFunction<TIsAppWindowReady>> isAppWindowReady;
 }
 
 typedef Pointer<BDWAPI> TBitsdojoWindowAPI();

--- a/bitsdojo_window_linux/lib/src/window.dart
+++ b/bitsdojo_window_linux/lib/src/window.dart
@@ -10,7 +10,7 @@ import 'package:bitsdojo_window_platform_interface/bitsdojo_window_platform_inte
 var isInsideDoWhenWindowReady = false;
 
 bool isValidHandle(int? handle, String operation) {
-  if (handle == null) {
+  if (handle == null || handle == 0) {
     print("Could not $operation - handle is null");
     return false;
   }

--- a/bitsdojo_window_linux/lib/src/window.dart
+++ b/bitsdojo_window_linux/lib/src/window.dart
@@ -11,8 +11,8 @@ import 'package:bitsdojo_window_platform_interface/bitsdojo_window_platform_inte
 var isInsideDoWhenWindowReady = false;
 
 bool isValidHandle(int? handle, String operation) {
-  if (handle == null) {
-    debugPrint("Could not $operation - handle is null");
+  if (handle == null || handle == 0) {
+    debugPrint("Could not $operation - handle is ${handle == null ? 'null' : '0'}");
     return false;
   }
   return true;

--- a/bitsdojo_window_linux/linux/api.cpp
+++ b/bitsdojo_window_linux/linux/api.cpp
@@ -18,7 +18,8 @@ BDWAPI _theAPI = {
     minimizeWindow,
     maximizeWindow,
     unmaximizeWindow,
-    setWindowTitle
+    setWindowTitle,
+    isAppWindowReady
 };
 
 } // namespace bitsdojo_window

--- a/bitsdojo_window_linux/linux/api.h
+++ b/bitsdojo_window_linux/linux/api.h
@@ -7,6 +7,9 @@
 typedef GtkWindow* (*TGetAppWindowHandle)();
 GtkWindow* getAppWindowHandle();
 
+typedef int (*TIsAppWindowReady)();
+int isAppWindowReady();
+
 namespace bitsdojo_window {
 
 typedef struct _BDWAPI {
@@ -26,6 +29,7 @@ typedef struct _BDWAPI {
     TMaximizeWindow maximizeWindow;
     TUnmaximizeWindow unmaximizeWindow;
     TSetWindowTitle setWindowTitle;
+    TIsAppWindowReady isAppWindowReady;
 } BDWAPI;
 
 }  // namespace bitsdojo_window


### PR DESCRIPTION
- Compare URL: https://github.com/kingdomseed/desktop_title_bar_controls/compare/master...fix/linux-init-race?expand=1
- Base: master
- Head: fix/linux-init-race

PR Title
Linux: harden startup against race conditions (getAppWindowHandle + handle readiness)

PR Body
Summary

- Avoids release-only startup segfaults on Linux by turning an early-call race into a safe “not ready yet” state.


- Native (Linux):
    - Guard plugin pointer with std::atomic and return nullptr if not ready.
    - Cache GtkWindow* on “realize”; reuse cached handle; log once when plugin/view not ready.
- Dart (Linux):
    - Treat handle == 0 as invalid; drop assert in constructor and defer init.
    - After first frame (doWhenWindowReady), attempt to set the handle once if available.

Rationale

- Issue #230 reports a segfault when getAppWindowHandle() races with plugin registration/view realization. This makes calls deterministic and crash-free without blocking GTK.

Testing

- Repro app calling appWindow.show() early vs inside doWhenWindowReady.
- Release builds on X11 and Wayland; verify no segfault and single, non-spammy warning on early access.
- Confirm Windows/macOS unaffected.

Notes for Reviewers

- No blocking or busy-waiting; retries are async/one-shot.
- Consider a follow-up to export isAppWindowReady() and clear the cache on destroy/unrealize (hot restart hardening).

Checklist

- [ ] Verify Linux example runs without segfault when calling early and inside doWhenWindowReady.
- [ ] Validate on X11 and Wayland (Ubuntu/Pop!_OS/Fedora).
- [ ] Check native logs show at most one warning when called too early.
- [ ] Confirm no regressions on Windows/macOS paths.
- [ ] Optional: ASAN build shows no null deref.

Breaking Changes

- None. Linux only; behavior is more robust for early calls.

Files Touched

- bitsdojo_window_linux/linux/bitsdojo_window_plugin.cpp
- bitsdojo_window_linux/lib/src/app_window.dart
- bitsdojo_window_linux/lib/src/window.dart
- bitsdojo_window_linux/lib/src/bitsdojo_window_linux_real.dart